### PR TITLE
Change permission representation from rationals to reals

### DIFF
--- a/tutorial/expressions-and-assertions.md
+++ b/tutorial/expressions-and-assertions.md
@@ -156,7 +156,7 @@ Viper's built-in map type `Map[T, U]` represents immutable partial maps from ele
 
 Expressions of type `Perm` are real numbers and are usually used to represent permission amounts (though they can be used for other purposes).
 
-* Fractional permission expressions `e1/e2`, where both `e1` and `e2` are integers, evaluate to a Perm value that is a rational whose numerator is `e1` and whose denominator is `e2`. A well-definedness condition is that `e2` must not equal 0. `e1/e2` can also denote a permission amount divided by an integer if `e1` is an expression of type `Perm` and `e2` is an expression of type `Int`.
+* Fractional permission expressions `e1/e2`, where both `e1` and `e2` are integers, evaluate to a Perm value whose numerator is `e1` and whose denominator is `e2`. A well-definedness condition is that `e2` must not equal 0. `e1/e2` can also denote a permission amount divided by an integer if `e1` is an expression of type `Perm` and `e2` is an expression of type `Int`.
 
 * The `Perm`-typed literals `none` and  `write` denote no permission and a full permission, corresponding to `0/1` and `1/1`, respectively.
 

--- a/tutorial/expressions-and-assertions.md
+++ b/tutorial/expressions-and-assertions.md
@@ -4,7 +4,7 @@
 
 Viper supports a number of different kinds of expressions, which can be evaluated to a value of one of the types supported in Viper.
 
-The primitive types supported in Viper are booleans (`Bool`), integers (`Int`), permission amounts (`Perm`), denoting rational numbers, and references to heap objects (`Ref`). In addition, there are built-in parameterised set (`Set[T]`), multiset (`Multiset[T]`), sequence (`Seq[T]`), and map (`Map[T, U]`) types, and users can define custom types using [domains](#domains).
+The primitive types supported in Viper are booleans (`Bool`), integers (`Int`), permission amounts (`Perm`), denoting real numbers, and references to heap objects (`Ref`). In addition, there are built-in parameterised set (`Set[T]`), multiset (`Multiset[T]`), sequence (`Seq[T]`), and map (`Map[T, U]`) types, and users can define custom types using [domains](#domains).
 
 Evaluating an expression never changes the state of the program, i.e., expression evaluation has no side effects. However, expression evaluation comes with well-definedness conditions for some expressions: evaluating an expression can cause a verification failure if the expression is not well-defined in the current program state; this leads to a verification error. As an example, the expression `x % y` is not well-defined if `y` is equal to zero, and the expression `o.f` is only well-defined if the current method has the permission to read `o.f` (which also implies that `o` is not null).
 
@@ -154,9 +154,9 @@ Viper's built-in map type `Map[T, U]` represents immutable partial maps from ele
 
 ### Perm expressions
 
-Expressions of type `Perm` are rational numbers and are usually used to represent permission amounts (though they can be used for other purposes).
+Expressions of type `Perm` are real numbers and are usually used to represent permission amounts (though they can be used for other purposes).
 
-* Fractional permission expressions `e1/e2`, where both `e1` and `e2` are integers, evaluate to a Perm value whose numerator is `e1` and whose denominator is `e2`. A well-definedness condition is that `e2` must not equal 0. `e1/e2` can also denote a permission amount divided by an integer if `e1` is an expression of type `Perm` and `e2` is an expression of type `Int`.
+* Fractional permission expressions `e1/e2`, where both `e1` and `e2` are integers, evaluate to a Perm value that is a rational whose numerator is `e1` and whose denominator is `e2`. A well-definedness condition is that `e2` must not equal 0. `e1/e2` can also denote a permission amount divided by an integer if `e1` is an expression of type `Perm` and `e2` is an expression of type `Int`.
 
 * The `Perm`-typed literals `none` and  `write` denote no permission and a full permission, corresponding to `0/1` and `1/1`, respectively.
 

--- a/tutorial/structure.md
+++ b/tutorial/structure.md
@@ -129,7 +129,7 @@ define link(x, y) {
 * `Ref` for references (to objects, except for the built-in `Ref` constant `null`)
 * `Bool` for Boolean values
 * `Int` for mathematical (unbounded) integers
-* `Rational` for mathematical (unbounded) rationals
+* `Rational` for mathematical (unbounded) rationals (this type is expected to be deprecated in the summer 2023 release)
 * `Perm` for permission amounts (see the [section on permissions](#permissions) for details)
 * `Seq[T]` for immutable sequences with element type `T`
 * `Set[T]` for immutable sets with element type `T`

--- a/tutorial/termination.md
+++ b/tutorial/termination.md
@@ -44,7 +44,7 @@ Viper's standard library provides definitions of well-founded orders for most ty
 |`Ref`<br>(`ref.vpr`)| `r1 <_ r2 <==> r1 == null && r2 != null`
 |`Bool`<br>(`bool.vpr`)| `b1 <_ b2 <==> b1 == false && b2 == true`
 |`Int`<br>(`int.vpr`)| `i1 <_ i2 <==> i1 < i2 && 0 <= i2`
-|`Rational`<br>(`rational.vpr`):| `r1 <_ r2 <==> r1 <= r2 - 1/1 && 0/1 <= r2`
+|`Rational`<br>(`rational.vpr`, rationals will be deprecated in the summer 2023 release):| `r1 <_ r2 <==> r1 <= r2 - 1/1 && 0/1 <= r2`
 |`Perm`<br>(`perm.vpr`)| `p1 <_ p2 <==> p1 <= p2 - write && none <= p2`
 |`Seq[T]`<br>(`seq.vpr`)| `s1 <_ s2 <==> \|s1\| < \|s2\|`
 |`Set[T]`<br>(`set.vpr`)| `s1 <_ s2 <==> \|s1\| < \|s2\|`


### PR DESCRIPTION
Viper uses the SMT real type to represent permissions. However, the tutorial presents the `Perm` type to denote the rationals. Since SMT-LIB does not have a built-in rational type and because non-linear arithmetic has better properties for reals at the SMT level, Viper should keep using the SMT real type to represent permissions. This PR reflects that `Perm` represents the reals and also announces that the rational type will be deprecated in the summer 2023 release (the rational type is currently just a type synonym for `Perm`).